### PR TITLE
Download as zip

### DIFF
--- a/src/main/java/com/google/sps/tasks/PrepareDownload.java
+++ b/src/main/java/com/google/sps/tasks/PrepareDownload.java
@@ -6,6 +6,7 @@ import com.google.appengine.tools.cloudstorage.GcsOutputChannel;
 import com.google.appengine.tools.cloudstorage.GcsService;
 import com.google.appengine.tools.cloudstorage.GcsServiceFactory;
 import com.google.sps.workspace.Workspace;
+import com.google.sps.workspace.WorkspaceArchive;
 import com.google.sps.workspace.WorkspaceFactory;
 import java.io.IOException;
 import java.nio.channels.Channels;
@@ -49,7 +50,8 @@ public class PrepareDownload extends HttpServlet {
     GcsOutputChannel outputChannel = instance.createOrReplace(filename, options);
 
     try {
-      w.getArchive().archive(Channels.newOutputStream(outputChannel));
+      w.getArchive()
+          .archive(Channels.newOutputStream(outputChannel), WorkspaceArchive.ArchiveType.ZIP);
 
       w.updateDownloadName(downloadID, filename.getObjectName());
     } catch (InterruptedException | ExecutionException e) {

--- a/src/main/java/com/google/sps/tasks/PrepareDownload.java
+++ b/src/main/java/com/google/sps/tasks/PrepareDownload.java
@@ -6,7 +6,7 @@ import com.google.appengine.tools.cloudstorage.GcsOutputChannel;
 import com.google.appengine.tools.cloudstorage.GcsService;
 import com.google.appengine.tools.cloudstorage.GcsServiceFactory;
 import com.google.sps.workspace.Workspace;
-import com.google.sps.workspace.WorkspaceArchive;
+import com.google.sps.workspace.WorkspaceArchive.ArchiveType;
 import com.google.sps.workspace.WorkspaceFactory;
 import java.io.IOException;
 import java.nio.channels.Channels;
@@ -50,8 +50,7 @@ public class PrepareDownload extends HttpServlet {
     GcsOutputChannel outputChannel = instance.createOrReplace(filename, options);
 
     try {
-      w.getArchive()
-          .archive(Channels.newOutputStream(outputChannel), WorkspaceArchive.ArchiveType.ZIP);
+      w.getArchive(ArchiveType.ZIP).archive(Channels.newOutputStream(outputChannel));
 
       w.updateDownloadName(downloadID, filename.getObjectName());
     } catch (InterruptedException | ExecutionException e) {

--- a/src/main/java/com/google/sps/workspace/Workspace.java
+++ b/src/main/java/com/google/sps/workspace/Workspace.java
@@ -4,6 +4,7 @@ import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.ValueEventListener;
+import com.google.sps.workspace.WorkspaceArchive.ArchiveType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -114,7 +115,7 @@ public class Workspace {
     return reference.getKey();
   }
 
-  public WorkspaceArchive getArchive() {
-    return new WorkspaceArchive(this);
+  public WorkspaceArchive getArchive(ArchiveType type) {
+    return new WorkspaceArchive(this, type);
   }
 }

--- a/src/main/webapp/workspace/index.html
+++ b/src/main/webapp/workspace/index.html
@@ -35,7 +35,7 @@
           <input type="file" id="upload-files" class="hidden" oninput="filesUploaded()" multiple/>
 
           <button class="permanent-tab tab" id="downloadButton" onclick="downloadFiles()">Download</button>
-          <a class="hidden" id="downloadLink" download="workspace.tar.gz">Download</a>
+          <a class="hidden" id="downloadLink" download="workspace.zip">Download</a>
 
           <button class="permanent-tab tab" id="jitsi-join" onclick="addJitsiWindow()">Join Meeting</button>
         </div>

--- a/src/test/java/com/google/sps/tasks/PrepareDownloadTest.java
+++ b/src/test/java/com/google/sps/tasks/PrepareDownloadTest.java
@@ -13,6 +13,7 @@ import com.google.appengine.tools.cloudstorage.GcsOutputChannel;
 import com.google.appengine.tools.cloudstorage.GcsService;
 import com.google.sps.workspace.Workspace;
 import com.google.sps.workspace.WorkspaceArchive;
+import com.google.sps.workspace.WorkspaceArchive.ArchiveType;
 import com.google.sps.workspace.WorkspaceFactory;
 import java.io.BufferedReader;
 import java.io.OutputStream;
@@ -55,15 +56,14 @@ public class PrepareDownloadTest {
     when(workspaceFactory.fromWorkspaceID(eq(workspaceID))).thenReturn(workspace);
     when(instance.createOrReplace(any(GcsFilename.class), any(GcsFileOptions.class)))
         .thenReturn(outputChannel);
-    when(workspace.getArchive()).thenReturn(archive);
+    when(workspace.getArchive(ArchiveType.ZIP)).thenReturn(archive);
 
     servlet.doPost(req, resp);
 
     verify(workspaceFactory, times(1)).fromWorkspaceID(workspaceID);
     verify(instance, times(1)).createOrReplace(filenameCaptor.capture(), any(GcsFileOptions.class));
     assertEquals(workspaceID + '/' + downloadID, filenameCaptor.getValue().getObjectName());
-    verify(archive, times(1))
-        .archive(any(OutputStream.class), eq(WorkspaceArchive.ArchiveType.ZIP));
+    verify(archive, times(1)).archive(any(OutputStream.class));
     verify(workspace, times(1))
         .updateDownloadName(downloadID, filenameCaptor.getValue().getObjectName());
   }

--- a/src/test/java/com/google/sps/tasks/PrepareDownloadTest.java
+++ b/src/test/java/com/google/sps/tasks/PrepareDownloadTest.java
@@ -62,7 +62,8 @@ public class PrepareDownloadTest {
     verify(workspaceFactory, times(1)).fromWorkspaceID(workspaceID);
     verify(instance, times(1)).createOrReplace(filenameCaptor.capture(), any(GcsFileOptions.class));
     assertEquals(workspaceID + '/' + downloadID, filenameCaptor.getValue().getObjectName());
-    verify(archive, times(1)).archive(any(OutputStream.class));
+    verify(archive, times(1))
+        .archive(any(OutputStream.class), eq(WorkspaceArchive.ArchiveType.ZIP));
     verify(workspace, times(1))
         .updateDownloadName(downloadID, filenameCaptor.getValue().getObjectName());
   }

--- a/src/test/java/com/google/sps/workspace/WorkspaceArchiveTest.java
+++ b/src/test/java/com/google/sps/workspace/WorkspaceArchiveTest.java
@@ -2,17 +2,24 @@ package com.google.sps.workspace;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.sps.workspace.WorkspaceArchive.ArchiveType;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import org.apache.commons.compress.archivers.ArchiveOutputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -23,7 +30,8 @@ public class WorkspaceArchiveTest {
   @Mock Workspace workspace;
   @Mock Future<List<WorkspaceFile>> futureFiles;
   @Mock Future<String> futureString;
-  @Mock TarArchiveOutputStream tarOut;
+  @Mock ArchiveOutputStream archiveOut;
+  @Mock OutputStream out;
   @Mock WorkspaceFile file;
 
   @Test(expected = NullPointerException.class)
@@ -37,7 +45,7 @@ public class WorkspaceArchiveTest {
   }
 
   @Test
-  public void archive() throws InterruptedException, ExecutionException, IOException {
+  public void archiveTar() throws InterruptedException, ExecutionException, IOException {
     final int NUM_FILES = 3;
     final String FILENAME = "FILENAME";
     final String CONTENTS = "CONTENTS";
@@ -53,17 +61,47 @@ public class WorkspaceArchiveTest {
     when(file.getContents()).thenReturn(futureString);
     when(futureString.get()).thenReturn(CONTENTS);
 
-    new WorkspaceArchive(workspace, ArchiveType.TAR).archive(tarOut);
+    new WorkspaceArchive(workspace, ArchiveType.TAR).archive(archiveOut);
 
     verify(workspace, times(1)).getFiles();
     verify(file, times(NUM_FILES)).getFilename();
     verify(file, times(NUM_FILES)).getContents();
 
-    verify(tarOut, times(NUM_FILES)).putArchiveEntry(any());
-    verify(tarOut, times(NUM_FILES)).write(eq(CONTENTS.getBytes()));
-    verify(tarOut, times(NUM_FILES)).closeArchiveEntry();
+    verify(archiveOut, times(NUM_FILES)).putArchiveEntry(any(TarArchiveEntry.class));
+    verify(archiveOut, times(NUM_FILES)).write(eq(CONTENTS.getBytes()));
+    verify(archiveOut, times(NUM_FILES)).closeArchiveEntry();
 
-    verify(tarOut, times(1)).close();
+    verify(archiveOut, times(1)).close();
+  }
+
+  @Test
+  public void archiveZip() throws InterruptedException, ExecutionException, IOException {
+    final int NUM_FILES = 3;
+    final String FILENAME = "FILENAME";
+    final String CONTENTS = "CONTENTS";
+
+    List<WorkspaceFile> files = new ArrayList<>();
+    for (int i = 0; i < NUM_FILES; i++) {
+      files.add(file);
+    }
+
+    when(workspace.getFiles()).thenReturn(futureFiles);
+    when(futureFiles.get()).thenReturn(files);
+    when(file.getFilename()).thenReturn(FILENAME);
+    when(file.getContents()).thenReturn(futureString);
+    when(futureString.get()).thenReturn(CONTENTS);
+
+    new WorkspaceArchive(workspace, ArchiveType.ZIP).archive(archiveOut);
+
+    verify(workspace, times(1)).getFiles();
+    verify(file, times(NUM_FILES)).getFilename();
+    verify(file, times(NUM_FILES)).getContents();
+
+    verify(archiveOut, times(NUM_FILES)).putArchiveEntry(any(ZipArchiveEntry.class));
+    verify(archiveOut, times(NUM_FILES)).write(eq(CONTENTS.getBytes()));
+    verify(archiveOut, times(NUM_FILES)).closeArchiveEntry();
+
+    verify(archiveOut, times(1)).close();
   }
 
   @Test(expected = ExecutionException.class)
@@ -71,6 +109,26 @@ public class WorkspaceArchiveTest {
     when(workspace.getFiles()).thenReturn(futureFiles);
     when(futureFiles.get()).thenThrow(new ExecutionException(new Exception()));
 
-    new WorkspaceArchive(workspace, ArchiveType.TAR).archive(tarOut);
+    new WorkspaceArchive(workspace, ArchiveType.TAR).archive(archiveOut);
+  }
+
+  @Test
+  public void archiveHelperTar() throws Exception {
+    WorkspaceArchive archive = spy(new WorkspaceArchive(workspace, ArchiveType.TAR));
+    doNothing().when(archive).archive(any(ArchiveOutputStream.class));
+
+    archive.archive(out);
+
+    verify(archive, times(1)).archive(any(TarArchiveOutputStream.class));
+  }
+
+  @Test
+  public void archiveHelperZip() throws Exception {
+    WorkspaceArchive archive = spy(new WorkspaceArchive(workspace, ArchiveType.ZIP));
+    doNothing().when(archive).archive(any(ArchiveOutputStream.class));
+
+    archive.archive(out);
+
+    verify(archive, times(1)).archive(any(ZipArchiveOutputStream.class));
   }
 }

--- a/src/test/java/com/google/sps/workspace/WorkspaceArchiveTest.java
+++ b/src/test/java/com/google/sps/workspace/WorkspaceArchiveTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.sps.workspace.WorkspaceArchive.ArchiveType;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,7 +28,12 @@ public class WorkspaceArchiveTest {
 
   @Test(expected = NullPointerException.class)
   public void workspaceArchiveNullWorkspace() {
-    new WorkspaceArchive(null);
+    new WorkspaceArchive(null, ArchiveType.ZIP);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void workspaceArchiveNullType() {
+    new WorkspaceArchive(workspace, null);
   }
 
   @Test
@@ -47,7 +53,7 @@ public class WorkspaceArchiveTest {
     when(file.getContents()).thenReturn(futureString);
     when(futureString.get()).thenReturn(CONTENTS);
 
-    new WorkspaceArchive(workspace).archive(tarOut);
+    new WorkspaceArchive(workspace, ArchiveType.TAR).archive(tarOut);
 
     verify(workspace, times(1)).getFiles();
     verify(file, times(NUM_FILES)).getFilename();
@@ -65,6 +71,6 @@ public class WorkspaceArchiveTest {
     when(workspace.getFiles()).thenReturn(futureFiles);
     when(futureFiles.get()).thenThrow(new ExecutionException(new Exception()));
 
-    new WorkspaceArchive(workspace).archive(tarOut);
+    new WorkspaceArchive(workspace, ArchiveType.TAR).archive(tarOut);
   }
 }


### PR DESCRIPTION
Allows you to specify the type of archive (tar or zip) when archiving a workspace.
Default to a zip file for user requested archives.