### PR TITLE
Small ui fixes

### DIFF
--- a/src/main/webapp/dashboard.html
+++ b/src/main/webapp/dashboard.html
@@ -98,7 +98,7 @@
         </div>
 
         <br>
-        <div id= "delete">
+        <div id="delete" class="hidden">
           <button onclick="deleteClass()">Delete Class</button>
         </div>
         <br>

--- a/src/main/webapp/dashboard.js
+++ b/src/main/webapp/dashboard.js
@@ -213,6 +213,12 @@ function checkDeletionStatus(envID, row) {
   }));
 }
 
+function deleteEnv(row, envID, tok) {
+  row.querySelector(".envStatus").innerText = "deleting";
+  fetch(`/environment?envID=${envID}&idToken=${tok}`, {method: 'DELETE'});
+  checkDeletionStatus(envID, row);
+}
+
 function checkEnvStatus(envID, row) {
   getToken().then(tok => {
     fetch(`/environment?envID=${envID}&idToken=${tok}`).then(resp => resp.ok ? resp.json() : "failed").then(env => {
@@ -223,11 +229,7 @@ function checkEnvStatus(envID, row) {
       } else {
         const deleteButton = row.querySelector(".envDelete");
         deleteButton.disabled = false;
-        deleteButton.onclick = () => {
-          row.querySelector(".envStatus").innerText = "deleting";
-          getToken().then(tok => fetch(`/environment?envID=${envID}&idToken=${tok}`, {method: 'DELETE'}));
-          checkDeletionStatus(envID, row);
-        };
+        deleteButton.onclick = () => deleteEnv(row, envID, tok);
       }
     });
   });
@@ -254,11 +256,7 @@ function getEnvs() {
       for (var env of envs) {
        const row = addEnvRow(env.name, env.status);
   
-       row.querySelector(".envDelete").onclick = () => {
-        row.querySelector(".envStatus").innerText = "deleting";
-        fetch(`/environment?envID=${env.id}&idToken=${tok}`, {method: 'DELETE'});
-        checkDeletionStatus(env.id, row);
-       }; 
+       row.querySelector(".envDelete").onclick = () => deleteEnv(row, env.id, tok); 
       }
     });
   });

--- a/src/main/webapp/dashboard.js
+++ b/src/main/webapp/dashboard.js
@@ -283,8 +283,8 @@ function displayDelete(){
     const displayRequest = new Request("/get-role" + params, {method: "GET"});
     fetch(displayRequest).then(response => response.json()).then((role) => {
       var elem = document.getElementById("delete");
-      if (role !== "owner"){
-        elem.style.display = "none";
+      if (role === "owner"){
+        elem.classList.remove("hidden");
       }
     });
   });

--- a/src/main/webapp/dashboard.js
+++ b/src/main/webapp/dashboard.js
@@ -256,7 +256,7 @@ function getEnvs() {
   
        row.querySelector(".envDelete").onclick = () => {
         row.querySelector(".envStatus").innerText = "deleting";
-        fetch(`/environment?envID=${env.id}`, {method: 'DELETE'});
+        fetch(`/environment?envID=${env.id}&idToken=${tok}`, {method: 'DELETE'});
         checkDeletionStatus(env.id, row);
        }; 
       }

--- a/src/main/webapp/workspace/workspace.css
+++ b/src/main/webapp/workspace/workspace.css
@@ -22,6 +22,7 @@ body {
   flex: 1;
   flex-shrink: 1;
   overflow: hidden;
+  position: relative;
 }
 
 .column {


### PR DESCRIPTION
Prevent jitsi window from displaying on top of output terminal.
Make delete button on dashboard hidden by default. This prevents it from appearing briefly for ta's on page load.
Fix bug where environments that have been added cannot be deleted after a page load.