### PR TITLE
Disallow helping multiple students

### DIFF
--- a/src/main/java/com/google/sps/servlets/queue/NotifyStudent.java
+++ b/src/main/java/com/google/sps/servlets/queue/NotifyStudent.java
@@ -89,62 +89,77 @@ public class NotifyStudent extends HttpServlet {
           Key classKey = KeyFactory.stringToKey(classCode);
           Entity classEntity = datastore.get(txn, classKey);
 
-          // Query wait entity for particular day
-          Filter classWaitFilter = new FilterPredicate("classKey", FilterOperator.EQUAL, classKey);
-          Filter dateWaitFilter = new FilterPredicate("date", FilterOperator.EQUAL, currDate);
-          CompositeFilter waitFilter = CompositeFilterOperator.and(dateWaitFilter, classWaitFilter);
-          PreparedQuery query = datastore.prepare(new Query("Wait").setFilter(waitFilter));
-
-          // Get wait entity for particular day
-          Entity waitEntity;
-          if (query.countEntities() == 0) {
-            waitEntity = new Entity("Wait");
-            waitEntity.setProperty("classKey", classKey);
-            waitEntity.setProperty("date", currDate);
-            waitEntity.setProperty("waitDurations", new ArrayList<Long>());
-          } else {
-            waitEntity = query.asSingleEntity();
-          }
-
-          // Get student info and queue
-          ArrayList<EmbeddedEntity> queue =
-              (ArrayList<EmbeddedEntity>) classEntity.getProperty("studentQueue");
-          EmbeddedEntity delEntity =
-              queue.stream()
-                  .filter(elem -> (((String) elem.getProperty("uID")).equals(studentID)))
-                  .findFirst()
-                  .orElse(null);
-          ArrayList<Long> waitTimes = (ArrayList<Long>) waitEntity.getProperty("waitDurations");
-
-          // Update wait entity
-          Date timeEntered = (Date) delEntity.getProperty("timeEntered");
-
-          LocalDateTime currTime = LocalDateTime.now(clock);
-          LocalDateTime enteredTime =
-              timeEntered.toInstant().atZone(defaultZoneId).toLocalDateTime();
-          waitTimes.add(Duration.between(enteredTime, currTime).getSeconds());
-
-          // Update queue
-          queue.remove(delEntity);
-
-          // Get workspace ID
-          String workspaceID = (String) delEntity.getProperty("workspaceID");
-          factory.fromWorkspaceID(workspaceID).setTaUID(taID);
-
-          // Update beingHelped
           EmbeddedEntity beingHelped = (EmbeddedEntity) classEntity.getProperty("beingHelped");
-          EmbeddedEntity queueInfo = new EmbeddedEntity();
-          queueInfo.setProperty("taID", taID);
-          queueInfo.setProperty("workspaceID", workspaceID);
-          beingHelped.setProperty(studentID, queueInfo);
 
-          // Update entities
-          waitEntity.setProperty("waitDurations", waitTimes);
-          datastore.put(txn, waitEntity);
+          // Check if the ta is already helping someone.
+          boolean helpingAlredy =
+              beingHelped.getProperties().values().stream()
+                      .map(ent -> (EmbeddedEntity) ent)
+                      .filter(ent -> ent.getProperty("taID").equals(taID))
+                      .count()
+                  > 0;
 
-          classEntity.setProperty("studentQueue", queue);
-          classEntity.setProperty("beingHelped", beingHelped);
-          datastore.put(txn, classEntity);
+          if (!helpingAlredy) {
+            // Query wait entity for particular day
+            Filter classWaitFilter =
+                new FilterPredicate("classKey", FilterOperator.EQUAL, classKey);
+            Filter dateWaitFilter = new FilterPredicate("date", FilterOperator.EQUAL, currDate);
+            CompositeFilter waitFilter =
+                CompositeFilterOperator.and(dateWaitFilter, classWaitFilter);
+            PreparedQuery query = datastore.prepare(new Query("Wait").setFilter(waitFilter));
+
+            // Get wait entity for particular day
+            Entity waitEntity;
+            if (query.countEntities() == 0) {
+              waitEntity = new Entity("Wait");
+              waitEntity.setProperty("classKey", classKey);
+              waitEntity.setProperty("date", currDate);
+              waitEntity.setProperty("waitDurations", new ArrayList<Long>());
+            } else {
+              waitEntity = query.asSingleEntity();
+            }
+
+            // Get student info and queue
+            ArrayList<EmbeddedEntity> queue =
+                (ArrayList<EmbeddedEntity>) classEntity.getProperty("studentQueue");
+            EmbeddedEntity delEntity =
+                queue.stream()
+                    .filter(elem -> (((String) elem.getProperty("uID")).equals(studentID)))
+                    .findFirst()
+                    .orElse(null);
+            ArrayList<Long> waitTimes = (ArrayList<Long>) waitEntity.getProperty("waitDurations");
+
+            // Update wait entity
+            Date timeEntered = (Date) delEntity.getProperty("timeEntered");
+
+            LocalDateTime currTime = LocalDateTime.now(clock);
+            LocalDateTime enteredTime =
+                timeEntered.toInstant().atZone(defaultZoneId).toLocalDateTime();
+            waitTimes.add(Duration.between(enteredTime, currTime).getSeconds());
+
+            // Update queue
+            queue.remove(delEntity);
+
+            // Get workspace ID
+            String workspaceID = (String) delEntity.getProperty("workspaceID");
+            factory.fromWorkspaceID(workspaceID).setTaUID(taID);
+
+            // Update beingHelped
+            EmbeddedEntity queueInfo = new EmbeddedEntity();
+            queueInfo.setProperty("taID", taID);
+            queueInfo.setProperty("workspaceID", workspaceID);
+            beingHelped.setProperty(studentID, queueInfo);
+
+            // Update entities
+            waitEntity.setProperty("waitDurations", waitTimes);
+            datastore.put(txn, waitEntity);
+
+            classEntity.setProperty("studentQueue", queue);
+            classEntity.setProperty("beingHelped", beingHelped);
+            datastore.put(txn, classEntity);
+          } else {
+            response.sendError(HttpServletResponse.SC_CONFLICT);
+          }
 
           txn.commit();
           break;

--- a/src/main/java/com/google/sps/servlets/queue/NotifyStudent.java
+++ b/src/main/java/com/google/sps/servlets/queue/NotifyStudent.java
@@ -92,14 +92,14 @@ public class NotifyStudent extends HttpServlet {
           EmbeddedEntity beingHelped = (EmbeddedEntity) classEntity.getProperty("beingHelped");
 
           // Check if the ta is already helping someone.
-          boolean helpingAlredy =
+          boolean helpingAlready =
               beingHelped.getProperties().values().stream()
                       .map(ent -> (EmbeddedEntity) ent)
                       .filter(ent -> ent.getProperty("taID").equals(taID))
                       .count()
                   > 0;
 
-          if (!helpingAlredy) {
+          if (!helpingAlready) {
             // Query wait entity for particular day
             Filter classWaitFilter =
                 new FilterPredicate("classKey", FilterOperator.EQUAL, classKey);

--- a/src/main/webapp/queue/ta.js
+++ b/src/main/webapp/queue/ta.js
@@ -85,6 +85,7 @@ function getQueue() {
     const beinghelpedElem = document.getElementById('beingHelped');
 
     if (queue.helping) {
+      queueListElement.querySelectorAll(".notify-button").forEach((ele) => ele.classList.add("hidden"));
       beinghelpedElem.innerHTML = "";
       document.getElementById('beingHelped').appendChild(createHelpedElem(queue.helping.email, queue.helping.workspace));
     } else {

--- a/src/test/java/com/google/sps/servlets/queue/NotifyStudentTest.java
+++ b/src/test/java/com/google/sps/servlets/queue/NotifyStudentTest.java
@@ -157,4 +157,62 @@ public class NotifyStudentTest {
     ArrayList<Long> waitDurations = (ArrayList<Long>) testWaitEntity.getProperty("waitDurations");
     assertEquals((long) Duration.ofHours(24).getSeconds(), (long) waitDurations.get(0));
   }
+
+  @Test
+  public void doPostAlreadyHelping() throws Exception {
+    String WORKSPACE_ID = "WORKSPACE_ID";
+
+    Entity init = new Entity("Class");
+
+    init.setProperty("owner", "ownerID");
+    init.setProperty("name", "testClass");
+
+    EmbeddedEntity addQueue1 = new EmbeddedEntity();
+    addQueue1.setProperty("timeEntered", DATE);
+    addQueue1.setProperty("workspaceID", WORKSPACE_ID);
+    addQueue1.setProperty("uID", "studentID");
+
+    EmbeddedEntity addQueue2 = new EmbeddedEntity();
+    addQueue2.setProperty("timeEntered", DATE);
+    addQueue2.setProperty("workspaceID", WORKSPACE_ID);
+    addQueue2.setProperty("uID", "uID2");
+
+    init.setProperty("studentQueue", Arrays.asList(addQueue1, addQueue2));
+
+    EmbeddedEntity beingHelped = new EmbeddedEntity();
+    EmbeddedEntity helpingEntity = new EmbeddedEntity();
+    helpingEntity.setProperty("taID", "taID");
+    beingHelped.setProperty("uid3", helpingEntity);
+    init.setProperty("beingHelped", beingHelped);
+
+    datastore.put(init);
+
+    when(httpRequest.getParameter("taToken")).thenReturn("testID");
+    FirebaseToken mockToken = mock(FirebaseToken.class);
+    when(authInstance.verifyIdToken("testID")).thenReturn(mockToken);
+    when(mockToken.getUid()).thenReturn("taID");
+
+    when(httpRequest.getParameter("studentEmail")).thenReturn("test@google.com");
+
+    when(httpRequest.getParameter("classCode")).thenReturn(KeyFactory.keyToString(init.getKey()));
+
+    UserRecord mockUser = mock(UserRecord.class);
+    when(authInstance.getUserByEmail("test@google.com")).thenReturn(mockUser);
+    when(mockUser.getUid()).thenReturn("studentID");
+    doReturn(fixedClock.instant()).when(clock).instant();
+
+    alertStudent.doPost(httpRequest, httpResponse);
+
+    Entity testClassEntity = datastore.prepare(new Query("Class")).asSingleEntity();
+
+    ArrayList<EmbeddedEntity> testQueue =
+        (ArrayList<EmbeddedEntity>) testClassEntity.getProperty("studentQueue");
+    assertEquals(
+        KeyFactory.keyToString(init.getKey()), KeyFactory.keyToString(testClassEntity.getKey()));
+    assertEquals(2, testQueue.size());
+    assertEquals(testQueue.get(0).getProperty("uID"), "studentID");
+    assertEquals(testQueue.get(1).getProperty("uID"), "uID2");
+
+    verify(httpResponse, times(1)).sendError(HttpServletResponse.SC_CONFLICT);
+  }
 }


### PR DESCRIPTION
Prevent ta's from helping multiple students at the same time by:

- Hiding the `notify-student` buttons when the ta is helping someone.
- Sending an error on the server side if a ta tries to help multiple users.