### PR TITLE
Update link even if the student is being helped.

### DIFF
--- a/src/main/webapp/queue/student.js
+++ b/src/main/webapp/queue/student.js
@@ -76,6 +76,8 @@ function makeRequest(){
     
       } else {
         document.getElementById("beingHelped").innerText = "You are being helped by " + studentPosition.ta;
+        document.getElementById("workspaceRedirect").href = studentPosition.workspace;
+        document.getElementById("workspaceRedirect").innerText = "go to workspace";
         setTimeout(makeRequest, 1000);
       }
 


### PR DESCRIPTION
Fixes an issue where the workspace doesn't appear for the student if the refresh the page after a ta starts helping them.